### PR TITLE
fix: リポジトリ分析の指摘事項を是正

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -8,6 +8,6 @@ jobs:
   validate-branch-name:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Validate head branch name
         run: bash scripts/validate-branch-name.sh "${{ github.head_ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ jobs:
   quick-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run lightweight checks
         run: bash scripts/check.sh
 
   quick-check-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run lightweight checks (PowerShell)
         shell: pwsh
         run: ./scripts/check.ps1
@@ -24,9 +24,9 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v20
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
         with:
           globs: |
             **/*.md
@@ -34,18 +34,16 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install yamllint
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install yamllint
+        run: python -m pip install yamllint==1.37.1
       - name: Run yamllint
         run: yamllint .
 
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install shellcheck
         run: |
           sudo apt-get update

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 Thumbs.db
 
 # Editor
-.vscode/
+.vscode/*
+!.vscode/settings.json
 .idea/
 *.swp
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.watcherExclude": {
+    "**/target": true
+  }
+}

--- a/docs/adr/0001-language-agnostic-quality-foundation.md
+++ b/docs/adr/0001-language-agnostic-quality-foundation.md
@@ -1,0 +1,44 @@
+# 言語非依存の品質基盤を採用する / Adopt a Language-Agnostic Quality Foundation
+
+- Title: 言語非依存の品質基盤を採用する / Adopt a Language-Agnostic Quality Foundation
+- Status: Accepted
+- Created: 2026-02-24
+- Last Updated: 2026-02-24
+- Owner: Repository Maintainers
+- Language: JA/EN
+
+## Context
+
+このテンプレートは複数の言語・フレームワークで使う前提である。
+品質基準が言語依存だと、導入時の判断コストと運用負荷が増える。
+
+## Decision
+
+リポジトリ共通で最低限の品質基盤を定義する。
+具体的には、ドキュメント規約、ブランチ命名規約、軽量チェック、CI lint を共通適用する。
+
+## Consequences
+
+- 新規プロジェクト立ち上げ時の初期判断を削減できる。
+- 言語固有のルールは追加で定義する必要がある。
+
+## Alternatives
+
+- 言語別テンプレートを分離して運用する。
+- 各プロジェクトで個別に品質基準を作る。
+
+## 概要 / Summary (JA)
+
+言語に依存しない最小の品質基盤を採用し、共通運用を優先する。
+
+## Summary (EN)
+
+Adopt a minimal language-agnostic quality baseline to standardize operations.
+
+## 結論 / Conclusion (JA)
+
+本テンプレートでは、共通の品質基盤をデフォルト方針として継続する。
+
+## Conclusion (EN)
+
+This template will keep a shared quality foundation as the default policy.

--- a/docs/design/20260224-quality-check-architecture.md
+++ b/docs/design/20260224-quality-check-architecture.md
@@ -1,0 +1,52 @@
+# 品質チェック構成 / Quality Check Architecture
+
+- Title: 品質チェック構成 / Quality Check Architecture
+- Status: Approved
+- Created: 2026-02-24
+- Last Updated: 2026-02-24
+- Owner: Repository Maintainers
+- Language: JA/EN
+
+## 目的 / Objective
+
+ローカルとCIの品質チェック責務を分離して設計する。
+
+## アーキテクチャ / Architecture
+
+- `scripts/check.sh` / `scripts/check.ps1`: 構成とドキュメント規約の軽量検証
+- `.github/workflows/ci.yml`: lint と軽量検証の実行
+
+## インターフェース / Interfaces
+
+- ローカル: `bash scripts/check.sh`, `pwsh ./scripts/check.ps1`
+- CI: pull_request / push to main で自動実行
+
+## データ / Data Model
+
+この設計に永続データモデルはない。入力はリポジトリ内ファイル群。
+
+## 代替案 / Alternatives
+
+- すべてCIのみで検証し、ローカル検証を提供しない。
+- pre-commit フックに全検証を寄せる。
+
+## リスク / Risks
+
+- チェック項目が増えると実行時間が伸びる。
+- 規約変更時にスクリプト更新漏れが起きる。
+
+## 概要 / Summary (JA)
+
+軽量検証をローカルとCIの両方で実行可能にし、早期検知を重視する。
+
+## Summary (EN)
+
+Enable lightweight checks both locally and in CI for earlier feedback.
+
+## 結論 / Conclusion (JA)
+
+運用開始時点では、軽量スクリプト + CI lint の二層構成を採用する。
+
+## Conclusion (EN)
+
+Adopt a two-layer approach: lightweight scripts plus CI lint jobs.

--- a/docs/operations/20260224-quality-check-runbook.md
+++ b/docs/operations/20260224-quality-check-runbook.md
@@ -1,0 +1,48 @@
+# 品質チェック運用手順 / Quality Check Runbook
+
+- Title: 品質チェック運用手順 / Quality Check Runbook
+- Status: Approved
+- Created: 2026-02-24
+- Last Updated: 2026-02-24
+- Owner: Repository Maintainers
+- Language: JA/EN
+
+## 前提 / Preconditions
+
+- リポジトリルートでコマンドを実行する。
+- Bash または PowerShell が利用可能である。
+
+## 手順 / Procedure
+
+1. `bash scripts/check.sh` を実行する。
+2. Windows環境では `pwsh ./scripts/check.ps1` を実行する。
+3. 必要に応じて `shellcheck scripts/*.sh` `yamllint .` `markdownlint-cli2 "**/*.md"` を実行する。
+
+## ロールバック / Rollback
+
+- ルール追加で運用に支障がある場合は、変更したチェック項目を元に戻すPRを作成する。
+
+## 監視項目 / Monitoring
+
+- GitHub Actions の `CI` と `Branch Name Check` が成功していること。
+
+## 障害時対応 / Incident Response
+
+- CI失敗時はログから失敗ジョブを特定し、同じコマンドをローカルで再現する。
+- 再現不能な場合は実行環境差分を Issue に記録する。
+
+## 概要 / Summary (JA)
+
+品質チェックの実行手順と失敗時の対応フローを標準化する。
+
+## Summary (EN)
+
+Standardize execution and failure-response flow for quality checks.
+
+## 結論 / Conclusion (JA)
+
+運用ではローカル事前確認とCI結果確認の両方を必須とする。
+
+## Conclusion (EN)
+
+Require both local pre-checks and CI verification in regular operations.

--- a/docs/requirements/20260224-initial-quality-baseline.md
+++ b/docs/requirements/20260224-initial-quality-baseline.md
@@ -1,0 +1,54 @@
+# 初期品質ベースライン / Initial Quality Baseline
+
+- Title: 初期品質ベースライン / Initial Quality Baseline
+- Status: Approved
+- Created: 2026-02-24
+- Last Updated: 2026-02-24
+- Owner: Repository Maintainers
+- Language: JA/EN
+
+## 背景 / Background
+
+テンプレート利用時に、最低限満たすべき品質要件を明確化したい。
+
+## 目的 / Objective
+
+ドキュメントとCIの運用ルールを初期状態で担保する。
+
+## スコープ / Scope
+
+- docs 命名規則
+- 必須ヘッダ項目
+- CIでの lint 実行
+
+## 非スコープ / Out of Scope
+
+- 言語固有の静的解析ルール
+- プロダクト固有の性能要件
+
+## 受け入れ基準 / Acceptance Criteria
+
+- `scripts/check.sh` と `scripts/check.ps1` が規約違反を検知できる。
+- GitHub Actions で `markdownlint-cli2` / `yamllint` / `shellcheck` が実行される。
+- docs に要件・設計・運用・ADR の実体文書が最低1件ずつ存在する。
+
+## 制約 / Constraints
+
+- 軽量チェックは高速に完了すること。
+- テンプレートとして過剰な依存を追加しないこと。
+
+## 概要 / Summary (JA)
+
+本テンプレートの初期品質基準を定義し、運用のばらつきを抑える。
+
+## Summary (EN)
+
+Define a baseline quality standard to reduce operational inconsistency.
+
+## 結論 / Conclusion (JA)
+
+初期品質ベースラインを採用し、以後は変更理由をdocsで追跡する。
+
+## Conclusion (EN)
+
+Adopt the baseline and track future changes through repository docs.

--- a/docs/templates/adr-template.md
+++ b/docs/templates/adr-template.md
@@ -2,7 +2,8 @@
 
 - Title:
 - Status: Proposed | Accepted | Superseded
-- Date: YYYY-MM-DD
+- Created: YYYY-MM-DD
+- Last Updated: YYYY-MM-DD
 - Owner:
 - Language: JA/EN
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,6 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+check_doc_filename() {
+  local filepath="$1"
+  local pattern="$2"
+  local basename
+  basename="$(basename "$filepath")"
+  if [[ ! "$basename" =~ $pattern ]]; then
+    fail "Invalid docs filename: $filepath"
+  fi
+}
+
+check_doc_headers() {
+  local filepath="$1"
+  grep -Eq '^- Title:[[:space:]]*.*$' "$filepath" || fail "Missing header in $filepath: Title"
+  grep -Eq '^- Status:[[:space:]]*' "$filepath" || fail "Missing header in $filepath: Status"
+  grep -Eq '^- Created:[[:space:]]*' "$filepath" || fail "Missing header in $filepath: Created"
+  grep -Eq '^- Last Updated:[[:space:]]*' "$filepath" || fail "Missing header in $filepath: Last Updated"
+  grep -Eq '^- Owner:[[:space:]]*' "$filepath" || fail "Missing header in $filepath: Owner"
+  grep -Eq '^- Language:[[:space:]]*JA/EN[[:space:]]*$' "$filepath" || fail "Missing header in $filepath: Language: JA/EN"
+  grep -Fq '## 概要 / Summary (JA)' "$filepath" || fail "Missing section in $filepath: 概要 / Summary (JA)"
+  grep -Fq '## Summary (EN)' "$filepath" || fail "Missing section in $filepath: Summary (EN)"
+  grep -Fq '## 結論 / Conclusion (JA)' "$filepath" || fail "Missing section in $filepath: 結論 / Conclusion (JA)"
+  grep -Fq '## Conclusion (EN)' "$filepath" || fail "Missing section in $filepath: Conclusion (EN)"
+}
+
 echo "[check] markdown files exist"
 test -f README.md
 
@@ -42,6 +71,19 @@ test -f docs/templates/requirements-template.md
 test -f docs/templates/design-template.md
 test -f docs/templates/operations-template.md
 test -f docs/templates/adr-template.md
+
+echo "[check] docs filenames follow naming rules"
+while IFS= read -r filepath; do
+  check_doc_filename "$filepath" '^[0-9]{8}-[a-z0-9]+(-[a-z0-9]+)*\.md$'
+done < <(find docs/requirements docs/design docs/operations -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | sort)
+while IFS= read -r filepath; do
+  check_doc_filename "$filepath" '^[0-9]{4}-[a-z0-9]+(-[a-z0-9]+)*\.md$'
+done < <(find docs/adr -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | sort)
+
+echo "[check] docs required headers and bilingual summary/conclusion"
+while IFS= read -r filepath; do
+  check_doc_headers "$filepath"
+done < <(find docs/templates docs/requirements docs/design docs/operations docs/adr -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | sort)
 
 echo "[check] PR template includes docs review checklist"
 grep -Fq '仕様/挙動変更がある場合、関連docsを更新した' .github/pull_request_template.md


### PR DESCRIPTION
## 概要
- リポジトリ分析で挙がった指摘事項を一括で是正

## 背景・目的
- docs規約とテンプレートの不整合を解消する
- 軽量チェックの検証範囲を拡張する
- CIの依存固定と設定整合を改善する

## 変更内容
- ADRテンプレートのヘッダを `Created` / `Last Updated` に統一
- `scripts/check.sh` / `scripts/check.ps1` に以下を追加
  - docsファイル命名規則チェック
  - 必須ヘッダ項目チェック
  - Summary/Conclusion の JA/EN セクションチェック
- CI workflow の action 参照をコミットSHA固定化
- `yamllint` のバージョンを固定化 (`1.37.1`)
- `.gitignore` を更新し `.vscode/settings.json` の追跡を明示
- 実体 docs を4件追加（requirements/design/operations/adr）

## 確認項目
- [x] ローカルチェックを実行した
- [x] 主要な差分をセルフレビューした
- [x] 仕様/挙動変更がある場合、関連docsを更新した
- [x] ADRが必要な変更ではADRを追加した
- [x] ブランチ名が `type/short-slug` ルールに準拠している

### 更新対象docsのパス
- docs/adr/0001-language-agnostic-quality-foundation.md
- docs/requirements/20260224-initial-quality-baseline.md
- docs/design/20260224-quality-check-architecture.md
- docs/operations/20260224-quality-check-runbook.md
- docs/templates/adr-template.md

### 実行コマンド
```bash
bash scripts/check.sh
```

## 影響範囲・リスク
- 既存 docs の規約違反が将来のチェックで検知されるようになる
- PowerShell 実行環境がないローカルでは `check.ps1` の直接検証は未実施

## 補足
- `pwsh` がローカル環境にないため、Windows向けチェックはCIで補完