### PR TITLE
docs: ブランチ保護設定とリリース運用テンプレートを追加

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: "追加 / Added"
+      labels:
+        - "feature"
+        - "enhancement"
+    - title: "修正 / Fixed"
+      labels:
+        - "bug"
+        - "fix"
+    - title: "ドキュメント / Docs"
+      labels:
+        - "documentation"
+        - "docs"
+    - title: "その他 / Other"
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        with:
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project uses Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+
+- Branch protection policy runbook.
+- Release management runbook.
+- Release notes template.
+- GitHub release configuration and release workflow.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Codex（CLI/Agent）での開発を前提にした、**最小で実用的なリ�
 - `.github/pull_request_template.md`: 日本語 PR 記述テンプレート
 - `.github/ISSUE_TEMPLATE/*`: 日本語 Issue テンプレート（不具合/機能要望）
 - `.github/workflows/ci.yml`: 最低限の整合性チェック CI
+- `.github/workflows/release.yml`: タグ作成時の GitHub Release 作成
+- `.github/release.yml`: GitHub Release ノートのカテゴリ定義
 - `scripts/check.sh`: ローカルで実行する軽量チェック
 - `.editorconfig`: エディタ共通設定
 - `.gitignore`: 汎用除外設定
@@ -55,6 +57,14 @@ Codex（CLI/Agent）での開発を前提にした、**最小で実用的なリ�
 - `short-slug` は英小文字・数字・ハイフンのみ（先頭末尾ハイフン禁止）
 - ブランチ名は `Branch Name Check` workflow で PR 時に検証する
 - マージ後のブランチ自動削除は GitHub のリポジトリ設定（`Automatically delete head branches`）で有効化する
+- `main` にはブランチ保護を設定し、`CI` と `Branch Name Check` を必須チェックにする（詳細は `docs/operations/20260224-branch-protection-policy.md`）
+
+## リリース運用
+
+- 運用手順: `docs/operations/20260224-release-management-runbook.md`
+- リリースノートひな形: `docs/templates/release-notes-template.md`
+- 変更履歴: `CHANGELOG.md`
+- タグ `v*` を push すると `Release` workflow が GitHub Release を作成する
 
 ## ローカルチェック
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory stores project documentation alongside code.
 - `operations/`: 運用手順 / Operational runbooks
 - `adr/`: 重要判断記録 / Architectural Decision Records
 - `templates/`: 文書テンプレート / Document templates
+  - `release-notes-template.md`: リリースノート作成用 / Release notes template
 
 ## 命名規則 / Naming
 

--- a/docs/operations/20260224-branch-protection-policy.md
+++ b/docs/operations/20260224-branch-protection-policy.md
@@ -1,0 +1,61 @@
+# ブランチ保護ポリシー / Branch Protection Policy
+
+- Title: ブランチ保護ポリシー / Branch Protection Policy
+- Status: Approved
+- Created: 2026-02-24
+- Last Updated: 2026-02-24
+- Owner: Repository Maintainers
+- Language: JA/EN
+
+## 前提 / Preconditions
+
+- GitHub リポジトリ管理者権限を持つこと。
+- デフォルトブランチが `main` であること。
+
+## 手順 / Procedure
+
+1. `Settings > Branches > Add branch protection rule` を開く。
+2. `Branch name pattern` に `main` を設定する。
+3. 次の項目を有効化する。
+   - Require a pull request before merging
+   - Require approvals（1以上）
+   - Dismiss stale pull request approvals when new commits are pushed
+   - Require status checks to pass before merging
+   - Require conversation resolution before merging
+4. Required status checks に次を設定する。
+   - `CI`
+   - `Branch Name Check`
+5. 必要に応じて次を有効化する。
+   - Require branches to be up to date before merging
+   - Restrict who can push to matching branches
+   - Do not allow bypassing the above settings
+
+## ロールバック / Rollback
+
+- 運用に支障がある場合は、一時的に必須チェックを見直し、変更理由を PR または Issue に記録する。
+
+## 監視項目 / Monitoring
+
+- 保護ルールが `main` に適用されていること。
+- 必須チェックが継続的に成功していること。
+
+## 障害時対応 / Incident Response
+
+- 必須チェックの恒常的失敗が発生した場合は、失敗ジョブを修正する PR を優先作成する。
+- 緊急対応が必要な場合は、期間限定の運用例外を記録する。
+
+## 概要 / Summary (JA)
+
+`main` への直接変更を防ぎ、PR と必須チェックを通した変更のみを許可する。
+
+## Summary (EN)
+
+Protect `main` by enforcing PR-based changes and required checks.
+
+## 結論 / Conclusion (JA)
+
+標準運用として `main` のブランチ保護を常時有効にする。
+
+## Conclusion (EN)
+
+Keep branch protection on `main` enabled as a default operating policy.

--- a/docs/operations/20260224-release-management-runbook.md
+++ b/docs/operations/20260224-release-management-runbook.md
@@ -1,0 +1,53 @@
+# リリース運用手順 / Release Management Runbook
+
+- Title: リリース運用手順 / Release Management Runbook
+- Status: Approved
+- Created: 2026-02-24
+- Last Updated: 2026-02-24
+- Owner: Repository Maintainers
+- Language: JA/EN
+
+## 前提 / Preconditions
+
+- `main` へのマージ済み変更があること。
+- リリース対象の変更が `CHANGELOG.md` に反映されていること。
+- `CI` と `Branch Name Check` が成功していること。
+
+## 手順 / Procedure
+
+1. `CHANGELOG.md` の `Unreleased` を更新する。
+2. `docs/templates/release-notes-template.md` を使ってリリースノート案を作成する。
+3. バージョンタグを作成して push する（例: `v1.2.3`）。
+4. `Release` workflow が GitHub Release を作成したことを確認する。
+5. 公開後に `CHANGELOG.md` の `Unreleased` を空にし、次サイクルを開始する。
+
+## ロールバック / Rollback
+
+- 誤ったタグを作成した場合はタグを削除し、修正版タグを再作成する。
+- 誤ったリリースノートは GitHub Release 画面で修正する。
+
+## 監視項目 / Monitoring
+
+- `Release` workflow の成功
+- GitHub Release の本文とタグの整合性
+
+## 障害時対応 / Incident Response
+
+- workflow 失敗時は Actions ログを確認し、失敗原因を修正してタグを再pushする。
+- 権限不足やトークン問題はリポジトリ設定と権限を点検する。
+
+## 概要 / Summary (JA)
+
+タグベースでリリースを作成し、変更履歴とリリースノートを一貫運用する。
+
+## Summary (EN)
+
+Use tag-based releases with consistent changelog and release notes management.
+
+## 結論 / Conclusion (JA)
+
+本リポジトリでは、タグ作成を起点とするリリースフローを標準運用とする。
+
+## Conclusion (EN)
+
+Adopt a tag-driven release workflow as the standard release process.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,3 +5,4 @@ Store operational runbooks including release, monitoring, and incident response.
 
 - ファイル名: `YYYYMMDD-<slug>.md`
 - ひな形: `docs/templates/operations-template.md`
+- リリースノートひな形: `docs/templates/release-notes-template.md`

--- a/docs/templates/release-notes-template.md
+++ b/docs/templates/release-notes-template.md
@@ -1,0 +1,37 @@
+# リリースノートテンプレート / Release Notes Template
+
+- Title:
+- Status: Draft | In Review | Approved | Deprecated
+- Created: YYYY-MM-DD
+- Last Updated: YYYY-MM-DD
+- Owner:
+- Language: JA/EN
+
+## 対象バージョン / Target Version
+
+- Version:
+- Release Date:
+
+## 変更概要 / Highlights
+
+## 追加機能 / Added
+
+## 変更 / Changed
+
+## 修正 / Fixed
+
+## 非推奨・削除 / Deprecated and Removed
+
+## 破壊的変更 / Breaking Changes
+
+## 移行手順 / Migration Guide
+
+## 既知の制約 / Known Limitations
+
+## 概要 / Summary (JA)
+
+## Summary (EN)
+
+## 結論 / Conclusion (JA)
+
+## Conclusion (EN)

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -67,6 +67,10 @@ Assert-PathExists -Path "AGENTS.md" -PathType "Leaf"
 Write-Host "[check] workflow exists"
 Assert-PathExists -Path ".github/workflows/ci.yml" -PathType "Leaf"
 Assert-PathExists -Path ".github/workflows/branch-name-check.yml" -PathType "Leaf"
+Assert-PathExists -Path ".github/workflows/release.yml" -PathType "Leaf"
+
+Write-Host "[check] release config exists"
+Assert-PathExists -Path ".github/release.yml" -PathType "Leaf"
 
 Write-Host "[check] japanese PR template exists"
 Assert-PathExists -Path ".github/pull_request_template.md" -PathType "Leaf"
@@ -102,6 +106,7 @@ Assert-PathExists -Path "docs/templates/requirements-template.md" -PathType "Lea
 Assert-PathExists -Path "docs/templates/design-template.md" -PathType "Leaf"
 Assert-PathExists -Path "docs/templates/operations-template.md" -PathType "Leaf"
 Assert-PathExists -Path "docs/templates/adr-template.md" -PathType "Leaf"
+Assert-PathExists -Path "docs/templates/release-notes-template.md" -PathType "Leaf"
 
 Write-Host "[check] docs filenames follow naming rules"
 $datedDirs = @("docs/requirements", "docs/design", "docs/operations")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -39,6 +39,10 @@ test -f AGENTS.md
 echo "[check] workflow exists"
 test -f .github/workflows/ci.yml
 test -f .github/workflows/branch-name-check.yml
+test -f .github/workflows/release.yml
+
+echo "[check] release config exists"
+test -f .github/release.yml
 
 echo "[check] japanese PR template exists"
 test -f .github/pull_request_template.md
@@ -71,6 +75,7 @@ test -f docs/templates/requirements-template.md
 test -f docs/templates/design-template.md
 test -f docs/templates/operations-template.md
 test -f docs/templates/adr-template.md
+test -f docs/templates/release-notes-template.md
 
 echo "[check] docs filenames follow naming rules"
 while IFS= read -r filepath; do


### PR DESCRIPTION
## 概要
- ブランチ保護設定とリリース運用をテンプレートとして追加
- README と docs に導線を追加
- 軽量チェックに新規テンプレート/設定ファイル存在確認を追加

## 背景・目的
- テンプレート利用時に、保護設定とリリース手順をすぐ適用できるようにする
- 運用ルールを docs と設定ファイルで一貫管理する

## 変更内容
- 追加: `docs/operations/20260224-branch-protection-policy.md`
- 追加: `docs/operations/20260224-release-management-runbook.md`
- 追加: `docs/templates/release-notes-template.md`
- 追加: `CHANGELOG.md`
- 追加: `.github/release.yml`
- 追加: `.github/workflows/release.yml`（tag `v*` push で Release 作成）
- 更新: `README.md`（ブランチ保護/リリース運用の導線）
- 更新: `docs/README.md`, `docs/operations/README.md`
- 更新: `scripts/check.sh`, `scripts/check.ps1`（新規ファイルの存在チェック）

## 確認項目
- [x] ローカルチェックを実行した
- [x] 主要な差分をセルフレビューした
- [x] 仕様/挙動変更がある場合、関連docsを更新した
- [x] ADRが必要な変更ではADRを追加した
- [x] ブランチ名が `type/short-slug` ルールに準拠している

### 更新対象docsのパス
- docs/operations/20260224-branch-protection-policy.md
- docs/operations/20260224-release-management-runbook.md
- docs/templates/release-notes-template.md
- docs/README.md
- docs/operations/README.md
- README.md

### 実行コマンド
```bash
bash scripts/check.sh
```

## 影響範囲・リスク
- 新規 `Release` workflow は `v*` タグ push 時に GitHub Release を作成する
- 既存運用に対しては docs/設定追加が中心で、実装コードへの影響はない

## 補足
- `scripts/check.ps1` はローカルに `pwsh` が無いため未実行（CIで補完）
